### PR TITLE
ADJUST1-31 adding backend validation services.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,6 +10,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    PRISON_API_URL: https://api-dev.prison.service.justice.gov.uk
 
   # Switches off the allow list in the DEV env only.
   allowlist: null

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -9,6 +9,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    PRISON_API_URL: https://api-preprod.prison.service.justice.gov.uk
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,6 +9,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
+    PRISON_API_URL: https://api.prison.service.justice.gov.uk
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/client/PrisonApiClient.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.client
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
+
+@Service
+class PrisonApiClient(@Qualifier("prisonApiWebClient") private val webClient: WebClient) {
+  private inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>() {}
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun getSentencesAndOffences(bookingId: Long): List<SentenceAndOffences> {
+    log.info("Requesting sentence terms for bookingId $bookingId")
+    return webClient.get()
+      .uri("/api/offender-sentences/booking/$bookingId/sentences-and-offences")
+      .retrieve()
+      .bodyToMono(typeReference<List<SentenceAndOffences>>())
+      .block()!!
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/controller/AdjustmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/controller/AdjustmentsController.kt
@@ -21,8 +21,10 @@ import uk.gov.justice.digital.hmpps.adjustments.api.entity.AdjustmentSource
 import uk.gov.justice.digital.hmpps.adjustments.api.model.AdjustmentDetailsDto
 import uk.gov.justice.digital.hmpps.adjustments.api.model.AdjustmentDto
 import uk.gov.justice.digital.hmpps.adjustments.api.model.CreateResponseDto
+import uk.gov.justice.digital.hmpps.adjustments.api.model.ValidationMessage
 import uk.gov.justice.digital.hmpps.adjustments.api.service.AdjustmentsEventService
 import uk.gov.justice.digital.hmpps.adjustments.api.service.AdjustmentsService
+import uk.gov.justice.digital.hmpps.adjustments.api.service.ValidationService
 import java.util.UUID
 
 @RestController
@@ -31,6 +33,7 @@ import java.util.UUID
 class AdjustmentsController(
   val adjustmentsService: AdjustmentsService,
   val eventService: AdjustmentsEventService,
+  val validationService: ValidationService,
 ) {
 
   @PostMapping
@@ -158,5 +161,20 @@ class AdjustmentsController(
       adjustmentsService.delete(adjustmentId)
       eventService.delete(adjustmentId, it.person, AdjustmentSource.DPS)
     }
+  }
+
+  @PostMapping("/validate")
+  @Operation(
+    summary = "Validate an adjustments",
+    description = "Validate an adjustment.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "200", description = "Adjustment validation returned"),
+      ApiResponse(responseCode = "401", description = "Unauthorised, requires a valid Oauth2 token"),
+    ],
+  )
+  fun validate(@RequestBody adjustment: AdjustmentDetailsDto): List<ValidationMessage> {
+    return validationService.validate(adjustment)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/ValidationCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/ValidationCode.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Validation code details")
+enum class ValidationCode(val message: String, val validationType: ValidationType = ValidationType.VALIDATION) {
+  RADA_REDUCES_BY_MORE_THAN_HALF("Are you sure, as this reduction is more than 50% of the total additional days awarded?", ValidationType.WARNING),
+  MORE_RADAS_THAN_ADAS("The number of days restored cannot be more than the number of days rewarded."),
+  RADA_DATE_CANNOT_BE_FUTURE("Enter a Date of days restored date which is on or before today's date."),
+  RADA_DATA_MUST_BE_AFTER_SENTENCE_DATE("The date of days restored must be on or after start of sentences, %s."),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/ValidationMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/ValidationMessage.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Validation message details")
+data class ValidationMessage(
+  val code: ValidationCode,
+  val arguments: List<String> = listOf(),
+) {
+  val message
+    get() = String.format(code.message, *arguments.toTypedArray())
+  val type
+    get() = code.validationType
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/ValidationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/ValidationType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.model
+
+enum class ValidationType {
+  VALIDATION,
+  WARNING,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/prisonapi/OffenderOffence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/prisonapi/OffenderOffence.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.model.prisonapi
+
+import java.time.LocalDate
+
+data class OffenderOffence(
+  val offenderChargeId: Long,
+  val offenceStartDate: LocalDate?,
+  val offenceEndDate: LocalDate? = null,
+  val offenceCode: String,
+  val offenceDescription: String,
+  var indicators: List<String> = listOf(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/prisonapi/SentenceAndOffences.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/prisonapi/SentenceAndOffences.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external
+
+import uk.gov.justice.digital.hmpps.adjustments.api.model.prisonapi.OffenderOffence
+import uk.gov.justice.digital.hmpps.adjustments.api.model.prisonapi.SentenceTerms
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class SentenceAndOffences(
+  val bookingId: Long,
+  val sentenceSequence: Int,
+  val lineSequence: Int,
+  val caseSequence: Int,
+  val consecutiveToSequence: Int? = null,
+  val sentenceStatus: String,
+  val sentenceCategory: String,
+  val sentenceCalculationType: String,
+  val sentenceTypeDescription: String,
+  val sentenceDate: LocalDate,
+  val terms: List<SentenceTerms> = emptyList(),
+  val offences: List<OffenderOffence> = emptyList(),
+  val caseReference: String? = null,
+  val courtDescription: String? = null,
+  val fineAmount: BigDecimal? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/prisonapi/SentenceTerms.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/prisonapi/SentenceTerms.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.model.prisonapi
+
+data class SentenceTerms(
+  val years: Int = 0,
+  val months: Int = 0,
+  val weeks: Int = 0,
+  val days: Int = 0,
+  val code: String = "",
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/PrisonService.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.adjustments.api.client.PrisonApiClient
+import uk.gov.justice.digital.hmpps.calculatereleasedatesapi.model.external.SentenceAndOffences
+import java.time.LocalDate
+
+@Service
+class PrisonService(
+  private val prisonApiClient: PrisonApiClient,
+) {
+
+  fun getStartOfSentenceEnvelope(bookingId: Long): LocalDate {
+    return getSentencesAndOffences(bookingId).minOf { it.sentenceDate }
+  }
+
+  fun getSentencesAndOffences(bookingId: Long, filterActive: Boolean = true): List<SentenceAndOffences> {
+    return prisonApiClient.getSentencesAndOffences(bookingId)
+      .filter { !filterActive || it.sentenceStatus == "A" }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/ValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/ValidationService.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.adjustments.api.entity.AdjustmentType
+import uk.gov.justice.digital.hmpps.adjustments.api.model.AdjustmentDetailsDto
+import uk.gov.justice.digital.hmpps.adjustments.api.model.ValidationCode
+import uk.gov.justice.digital.hmpps.adjustments.api.model.ValidationMessage
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Service
+class ValidationService(
+  private val prisonService: PrisonService,
+  private val adjustmentService: AdjustmentsService,
+) {
+
+  fun validate(adjustment: AdjustmentDetailsDto): List<ValidationMessage> {
+    val startOfSentenceEnvelope = prisonService.getStartOfSentenceEnvelope(adjustment.bookingId)
+    if (adjustment.adjustmentType == AdjustmentType.RESTORATION_OF_ADDITIONAL_DAYS_AWARDED) {
+      return validateRada(adjustment, startOfSentenceEnvelope)
+    }
+    return emptyList()
+  }
+
+  private fun validateRada(adjustment: AdjustmentDetailsDto, startOfSentenceEnvelope: LocalDate): List<ValidationMessage> {
+    val validationMessages = mutableListOf<ValidationMessage>()
+
+    val adjustments = adjustmentService.findByPerson(adjustment.person)
+    val adaDays = adjustments.filter { it.adjustment.adjustmentType === AdjustmentType.ADDITIONAL_DAYS_AWARDED }.filter { it.adjustment.fromDate!!.isAfter(startOfSentenceEnvelope) }.map { it.adjustment.days!! }.reduceOrNull { acc, it -> acc + it } ?: 0
+    val radaDays =
+      (
+        adjustments.filter { it.adjustment.adjustmentType === AdjustmentType.RESTORATION_OF_ADDITIONAL_DAYS_AWARDED }
+          .filter { it.adjustment.fromDate!!.isAfter(startOfSentenceEnvelope) }.map { it.adjustment.days!! }
+          .reduceOrNull { acc, it -> acc + it } ?: 0
+        ) + adjustment.days!!
+
+    if (adaDays < radaDays) {
+      validationMessages.add(ValidationMessage(ValidationCode.MORE_RADAS_THAN_ADAS))
+    } else if (adaDays / 2 < radaDays) {
+      validationMessages.add(ValidationMessage(ValidationCode.RADA_REDUCES_BY_MORE_THAN_HALF))
+    }
+
+    if (adjustment.fromDate!!.isAfter(LocalDate.now())) {
+      validationMessages.add(ValidationMessage(ValidationCode.RADA_DATE_CANNOT_BE_FUTURE))
+    }
+
+    if (adjustment.fromDate.isBefore(startOfSentenceEnvelope)) {
+      val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+      validationMessages.add(ValidationMessage(ValidationCode.RADA_DATA_MUST_BE_AFTER_SENTENCE_DATE, listOf(startOfSentenceEnvelope.format(formatter))))
+    }
+
+    return validationMessages
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/controller/AdjustmentControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/controller/AdjustmentControllerIntTest.kt
@@ -6,6 +6,7 @@ import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.expectBodyList
 import uk.gov.justice.digital.hmpps.adjustments.api.config.ErrorResponse
@@ -17,8 +18,11 @@ import uk.gov.justice.digital.hmpps.adjustments.api.legacy.model.LegacyData
 import uk.gov.justice.digital.hmpps.adjustments.api.model.AdjustmentDetailsDto
 import uk.gov.justice.digital.hmpps.adjustments.api.model.AdjustmentDto
 import uk.gov.justice.digital.hmpps.adjustments.api.model.CreateResponseDto
+import uk.gov.justice.digital.hmpps.adjustments.api.model.ValidationCode
+import uk.gov.justice.digital.hmpps.adjustments.api.model.ValidationMessage
 import uk.gov.justice.digital.hmpps.adjustments.api.respository.AdjustmentRepository
 import uk.gov.justice.digital.hmpps.adjustments.api.service.EventType
+import uk.gov.justice.digital.hmpps.adjustments.api.wiremock.PrisonApiExtension
 import java.time.LocalDate
 import java.util.UUID
 
@@ -255,6 +259,34 @@ class AdjustmentControllerIntTest : SqsIntegrationTestBase() {
       .expectStatus().isCreated
       .returnResult(CreateResponseDto::class.java)
       .responseBody.blockFirst()!!.adjustmentId
+  }
+
+  @Test
+  fun validate() {
+    val validationMessages = webTestClient
+      .post()
+      .uri("/adjustments/validate")
+      .headers(
+        setAuthorisation(),
+      )
+      .bodyValue(
+        CREATED_ADJUSTMENT.copy(
+          fromDate = LocalDate.now().plusYears(1),
+          toDate = null,
+          days = 25,
+          bookingId = PrisonApiExtension.BOOKING_ID,
+          adjustmentType = AdjustmentType.RESTORATION_OF_ADDITIONAL_DAYS_AWARDED,
+        ),
+      )
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(object : ParameterizedTypeReference<List<ValidationMessage>>() {})
+      .returnResult().responseBody!!
+
+    assertThat(validationMessages.size).isEqualTo(2)
+    assertThat(validationMessages[0]).isEqualTo(ValidationMessage(ValidationCode.MORE_RADAS_THAN_ADAS))
+    assertThat(validationMessages[1]).isEqualTo(ValidationMessage(ValidationCode.RADA_DATE_CANNOT_BE_FUTURE))
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/integration/IntegrationTestBase.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.adjustments.api.integration
 
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
@@ -7,9 +8,11 @@ import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.adjustments.api.integration.helpers.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.adjustments.api.wiremock.PrisonApiExtension
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
+@ExtendWith(PrisonApiExtension::class)
 abstract class IntegrationTestBase {
 
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/ValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/ValidationServiceTest.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.adjustments.api.entity.AdjustmentType
+import uk.gov.justice.digital.hmpps.adjustments.api.model.AdjustmentDetailsDto
+import uk.gov.justice.digital.hmpps.adjustments.api.model.AdjustmentDto
+import uk.gov.justice.digital.hmpps.adjustments.api.model.ValidationCode
+import uk.gov.justice.digital.hmpps.adjustments.api.model.ValidationMessage
+import java.time.LocalDate
+import java.util.UUID
+
+class ValidationServiceTest {
+
+  private val prisonService = mock<PrisonService>()
+  private val adjustmentService = mock<AdjustmentsService>()
+  private val validationService = ValidationService(prisonService, adjustmentService)
+
+  private val BOOKING_ID = 1L
+  private val PERSON = "ABC123"
+  private val START_OF_SENTENCE_ENVELOPE = LocalDate.of(2022, 1, 1)
+  private val EXISTING_ADA = AdjustmentDetailsDto(
+    bookingId = BOOKING_ID,
+    sentenceSequence = null,
+    person = PERSON,
+    adjustmentType = AdjustmentType.ADDITIONAL_DAYS_AWARDED,
+    fromDate = LocalDate.now().minusDays(5),
+    toDate = null,
+    days = 50,
+  )
+
+  private val EXISTING_RADA = EXISTING_ADA.copy(
+    adjustmentType = AdjustmentType.RESTORATION_OF_ADDITIONAL_DAYS_AWARDED,
+    days = 20,
+  )
+
+  @BeforeEach
+  fun init() {
+    whenever(prisonService.getStartOfSentenceEnvelope(BOOKING_ID)).thenReturn(START_OF_SENTENCE_ENVELOPE)
+    whenever(adjustmentService.findByPerson(PERSON)).thenReturn(listOf(AdjustmentDto(UUID.randomUUID(), EXISTING_ADA), AdjustmentDto(UUID.randomUUID(), EXISTING_RADA)))
+  }
+
+  @Nested
+  inner class RadaTests {
+
+    val VALID_RADA = EXISTING_RADA.copy(days = 4)
+
+    @Test
+    fun `RADA days valid`() {
+      val result = validationService.validate(VALID_RADA)
+      assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `RADA reduce ADAs by more than 50 percent`() {
+      val result = validationService.validate(
+        VALID_RADA.copy(
+          days = 10,
+        ),
+      )
+      assertThat(result).isEqualTo(listOf(ValidationMessage(ValidationCode.RADA_REDUCES_BY_MORE_THAN_HALF)))
+    }
+
+    @Test
+    fun `RADA reduce ADAs by more ADAs`() {
+      val result = validationService.validate(
+        VALID_RADA.copy(
+          days = 40,
+        ),
+      )
+      assertThat(result).isEqualTo(listOf(ValidationMessage(ValidationCode.MORE_RADAS_THAN_ADAS)))
+    }
+
+    @Test
+    fun `Future dated radas`() {
+      val result = validationService.validate(
+        VALID_RADA.copy(
+          fromDate = LocalDate.now().plusDays(1),
+        ),
+      )
+      assertThat(result).isEqualTo(listOf(ValidationMessage(ValidationCode.RADA_DATE_CANNOT_BE_FUTURE)))
+    }
+
+    @Test
+    fun `Rada before sentence envelope start`() {
+      val result = validationService.validate(
+        VALID_RADA.copy(
+          fromDate = START_OF_SENTENCE_ENVELOPE.minusDays(1),
+        ),
+      )
+      assertThat(result).isEqualTo(
+        listOf(
+          ValidationMessage(
+            ValidationCode.RADA_DATA_MUST_BE_AFTER_SENTENCE_DATE,
+            listOf("01/01/2022"),
+          ),
+        ),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/wiremock/PrisonApiMockServer.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/*
+    This class mocks the prison-api.
+ */
+class PrisonApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+  companion object {
+    @JvmField
+    val prisonApi = PrisonApiMockServer()
+    const val BOOKING_ID = 123L
+  }
+  override fun beforeAll(context: ExtensionContext) {
+    prisonApi.start()
+    prisonApi.stubSentencesAndOffences()
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    prisonApi.resetRequests()
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    prisonApi.stop()
+  }
+}
+
+class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 8332
+  }
+
+  fun stubSentencesAndOffences() {
+    stubFor(
+      get("/api/offender-sentences/booking/${PrisonApiExtension.BOOKING_ID}/sentences-and-offences")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+                [
+                  {
+                    "bookingId": 123,
+                    "sentenceSequence": 1,
+                    "sentenceStatus": "A",
+                    "sentenceCategory": "2003",
+                    "sentenceCalculationType": "ADIMP_ORA",
+                    "sentenceTypeDescription": "Standard Determinate",
+                    "sentenceDate": "2015-03-17",
+                    "terms": [{
+                      "years": 0,
+                      "months": 20,
+                      "weeks": 0,
+                      "days": 0
+                    }],
+                    "offences": [
+                      {
+                        "offenderChargeId": 9991,
+                        "offenceStartDate": "2015-03-17",
+                        "offenceCode": "GBH",
+                        "offenceDescription": "Grievous bodily harm"
+                      }
+                    ]
+                  }
+                ]
+              """.trimIndent(),
+            )
+            .withStatus(200),
+        ),
+    )
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -47,6 +47,10 @@ hmpps:
   auth:
     url: http://localhost:8090/auth
 
+# Wiremock prison-api
+prison:
+  api:
+    url: http://localhost:8332
 
 hmpps.sqs:
   reactiveApi: true


### PR DESCRIPTION
So this is the work that adds all the business logic validation for RADAs. This validation does not do the data sanitisation validation which is currently done on the frontend, i.e. checking date is not null/a valid date, and checking days is entered and is a positive integer number.

I chose to do this validation on the backend as it seemed to belong there. I think we may need to add some of the sanitisation validation to the backend too. But at the moment it seems to make sense to have the field level validation on the frontend and this validation on the backend. But I'm open to any ideas.

