### PR TITLE
ADJUST1-97 fix to ADAs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/AdjustmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/AdjustmentsService.kt
@@ -64,7 +64,7 @@ class AdjustmentsService(
   }
 
   private fun additionalDaysAwarded(resource: AdjustmentDto, adjustment: Adjustment? = null): AdditionalDaysAwarded? {
-    if (resource.adjustmentType == AdjustmentType.ADDITIONAL_DAYS_AWARDED) {
+    if (resource.adjustmentType == AdjustmentType.ADDITIONAL_DAYS_AWARDED && resource.additionalDaysAwarded != null) {
       val additionalDaysAwarded = if (adjustment != null) adjustment.additionalDaysAwarded!! else AdditionalDaysAwarded()
       additionalDaysAwarded.apply {
         adjudicationId = resource.additionalDaysAwarded!!.adjudicationId


### PR DESCRIPTION
I had a review of the data model for ADAs. It looks like for MVP we won't be storing a link between the adjustment and adjudication. I considered reverting all the changes, but I think the database change will remain, it will probably be a one to many instead of the one to one we currently have. It seems that an adjustment will have many adjudications, i.e they could be two consecutive adjudications resulting in one adjustment.