### PR TITLE
ADJUST1-161 Unused remand being linked to remand and API allowing cre…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/entity/Adjustment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/entity/Adjustment.kt
@@ -64,11 +64,16 @@ data class Adjustment(
   @PrimaryKeyJoinColumn
   var unlawfullyAtLarge: UnlawfullyAtLarge? = null,
 
+  @OneToOne(mappedBy = "adjustment", cascade = [CascadeType.ALL], orphanRemoval = true)
+  @PrimaryKeyJoinColumn
+  var remand: Remand? = null,
+
   var prisonId: String? = null,
 ) {
   init {
     adjustmentHistory.forEach { it.adjustment = this }
     additionalDaysAwarded?.adjustment = this
     unlawfullyAtLarge?.adjustment = this
+    remand?.adjustment = this
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/entity/Remand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/entity/Remand.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.entity
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.MapsId
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import java.util.UUID
+
+@Entity
+@Table
+data class Remand(
+  @Id
+  val adjustmentId: UUID = UUID.randomUUID(),
+
+  @OneToOne
+  @MapsId
+  @JsonIgnore
+  var adjustment: Adjustment = Adjustment(),
+
+  @NotNull
+  @OneToOne
+  @JoinColumn(name = "unusedRemandId")
+  @JsonIgnore
+  var unusedRemand: Adjustment = Adjustment(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/AdditionalEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/AdditionalEvent.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.model
+
+import uk.gov.justice.digital.hmpps.adjustments.api.service.EventType
+import java.util.UUID
+
+data class AdditionalEvent(
+  val eventType: EventType,
+  val id: UUID,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/AdjustmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/AdjustmentDto.kt
@@ -28,6 +28,8 @@ data class AdjustmentDto(
   val additionalDaysAwarded: AdditionalDaysAwardedDto?,
   @Schema(description = "Additional details of a UAL adjustment")
   val unlawfullyAtLarge: UnlawfullyAtLargeDto?,
+  @Schema(description = "Additional details of a Remand adjustment")
+  val remand: RemandDto?,
   @Schema(description = "The prison where the prisoner was located at the time the adjustment was created (a 3 character code identifying the prison)", example = "LDS")
   val prisonId: String? = null,
   // View only fields

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/CreateResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/CreateResponseDto.kt
@@ -1,5 +1,10 @@
 package uk.gov.justice.digital.hmpps.adjustments.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import java.util.UUID
 
-data class CreateResponseDto(val adjustmentId: UUID)
+data class CreateResponseDto(
+  val adjustmentId: UUID,
+  @JsonIgnore
+  val additionalEvent: AdditionalEvent?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/RemandDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/model/RemandDto.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "The details of a remand adjustment")
+data class RemandDto(
+  @Schema(description = "Number of days for unused remand.")
+  val unusedDays: Int,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/respository/AdjustmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/respository/AdjustmentRepository.kt
@@ -21,4 +21,6 @@ interface AdjustmentRepository : JpaRepository<Adjustment, UUID> {
     fromDate: LocalDate,
     adjustmentTypes: List<AdjustmentType>? = listOf(REMAND, TAGGED_BAIL),
   ): List<Adjustment>
+
+  fun findByPersonAndDeleted(person: String, deleted: Boolean = false): List<Adjustment>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/AdjustmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/AdjustmentsService.kt
@@ -56,7 +56,7 @@ class AdjustmentsService(
     val adjustment = Adjustment(
       person = resource.person,
       daysCalculated = resource.days ?: daysCalculated!!,
-      days = resource.days,
+      days = if (resource.remand == null) resource.days else daysCalculated!!.minus(resource.remand.unusedDays),
       fromDate = resource.fromDate,
       toDate = resource.toDate,
       source = AdjustmentSource.DPS,
@@ -200,7 +200,7 @@ class AdjustmentsService(
       if (resource.toDate != null) (ChronoUnit.DAYS.between(resource.fromDate, resource.toDate) + 1).toInt() else null
     adjustment.apply {
       daysCalculated = resource.days ?: calculated!!
-      days = resource.days
+      days = if (resource.remand == null) resource.days else calculated!!.minus(resource.remand.unusedDays)
       fromDate = resource.fromDate
       toDate = resource.toDate
       source = AdjustmentSource.DPS

--- a/src/main/resources/migration/common/V7__remand.sql
+++ b/src/main/resources/migration/common/V7__remand.sql
@@ -1,0 +1,5 @@
+CREATE TABLE remand
+(
+    adjustment_id UUID           NOT NULL CONSTRAINT remand_pk PRIMARY KEY REFERENCES adjustment (id),
+    unused_remand_id UUID        NOT NULL CONSTRAINT unused_remand_fk REFERENCES adjustment (id)
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/controller/AdjustmentControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/controller/AdjustmentControllerIntTest.kt
@@ -407,6 +407,7 @@ class AdjustmentControllerIntTest : SqsIntegrationTestBase() {
       var unusedRemand = remand.remand!!.unusedRemand
 
       assertThat(remand.daysCalculated).isEqualTo(21)
+      assertThat(remand.days).isEqualTo(11)
       assertThat(unusedRemand.days).isEqualTo(10)
 
       awaitAtMost30Secs untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 2 }
@@ -426,6 +427,7 @@ class AdjustmentControllerIntTest : SqsIntegrationTestBase() {
       unusedRemand = remand.remand!!.unusedRemand
 
       assertThat(remand.daysCalculated).isEqualTo(21)
+      assertThat(remand.days).isEqualTo(16)
       assertThat(unusedRemand.days).isEqualTo(5)
 
       awaitAtMost30Secs untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 2 }
@@ -443,6 +445,7 @@ class AdjustmentControllerIntTest : SqsIntegrationTestBase() {
       remand = adjustmentRepository.findById(remandId).get()
       unusedRemand = adjustmentRepository.findById(unusedRemand.id).get()
       assertThat(remand.daysCalculated).isEqualTo(21)
+      assertThat(remand.days).isNull()
       assertThat(unusedRemand.deleted).isTrue
 
       awaitAtMost30Secs untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 2 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/integration/SqsIntegrationTestBase.kt
@@ -72,6 +72,6 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
   }
 
   fun getLatestMessage(): ReceiveMessageResponse? {
-    return adjustmentsQueue.sqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(adjustmentsQueue.queueUrl).build()).get()
+    return adjustmentsQueue.sqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(adjustmentsQueue.queueUrl).maxNumberOfMessages(10).build()).get()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/legacy/controller/LegacyAndAdjustmentsControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/legacy/controller/LegacyAndAdjustmentsControllerIntTest.kt
@@ -169,6 +169,7 @@ class LegacyAndAdjustmentsControllerIntTest : SqsIntegrationTestBase() {
       days = null,
       additionalDaysAwarded = null,
       unlawfullyAtLarge = null,
+      remand = null,
       lastUpdatedDate = LocalDateTime.now(),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/legacy/controller/LegacyControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/legacy/controller/LegacyControllerIntTest.kt
@@ -32,19 +32,7 @@ class LegacyControllerIntTest : SqsIntegrationTestBase() {
 
   @BeforeEach
   fun setup() {
-    val result = webTestClient
-      .post()
-      .uri("/legacy/adjustments")
-      .headers(
-        setAuthorisation(),
-      )
-      .header("Content-Type", LegacyController.LEGACY_CONTENT_TYPE)
-      .bodyValue(CREATED_ADJUSTMENT)
-      .exchange()
-      .expectStatus().isCreated
-      .returnResult(LegacyAdjustmentCreatedResponse::class.java)
-      .responseBody.blockFirst()!!
-    CREATED_ID = result.adjustmentId
+    CREATED_ID = createAdjustment(CREATED_ADJUSTMENT).adjustmentId
   }
 
   @Test
@@ -132,7 +120,6 @@ class LegacyControllerIntTest : SqsIntegrationTestBase() {
         CREATED_ADJUSTMENT.copy(
           adjustmentFromDate = CREATED_ADJUSTMENT.adjustmentFromDate!!.minusYears(1),
           adjustmentDays = 5,
-          adjustmentType = LegacyAdjustmentType.RX,
           comment = "Updated",
         ),
       )
@@ -156,7 +143,7 @@ class LegacyControllerIntTest : SqsIntegrationTestBase() {
     assertThat(adjustment.daysCalculated).isEqualTo(5)
 
     val legacyData = objectMapper.convertValue(adjustment.legacyData, LegacyData::class.java)
-    assertThat(legacyData).isEqualTo(LegacyData(bookingId = 1, sentenceSequence = 1, postedDate = LocalDate.now(), comment = "Updated", type = LegacyAdjustmentType.RX, active = true, migration = false))
+    assertThat(legacyData).isEqualTo(LegacyData(bookingId = 1, sentenceSequence = 1, postedDate = LocalDate.now(), comment = "Updated", type = LegacyAdjustmentType.UR, active = true, migration = false))
 
     awaitAtMost30Secs untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 1 }
     val latestMessage: String = getLatestMessage()!!.messages()[0].body()
@@ -198,6 +185,41 @@ class LegacyControllerIntTest : SqsIntegrationTestBase() {
       .header("Content-Type", LegacyController.LEGACY_CONTENT_TYPE)
       .exchange()
       .expectStatus().isNotFound
+  }
+
+  private fun createAdjustment(adjustment: LegacyAdjustment): LegacyAdjustmentCreatedResponse {
+    return webTestClient
+      .post()
+      .uri("/legacy/adjustments")
+      .headers(
+        setAuthorisation(),
+      )
+      .header("Content-Type", LegacyController.LEGACY_CONTENT_TYPE)
+      .bodyValue(adjustment)
+      .exchange()
+      .expectStatus().isCreated
+      .returnResult(LegacyAdjustmentCreatedResponse::class.java)
+      .responseBody.blockFirst()!!
+  }
+
+  @Test
+  fun `Create unused remand, and then create remand`() {
+    val unusedRemandId = createAdjustment(CREATED_ADJUSTMENT.copy(adjustmentType = LegacyAdjustmentType.UR, offenderNo = "QRE123"))
+    val remandId = createAdjustment(CREATED_ADJUSTMENT.copy(adjustmentType = LegacyAdjustmentType.RX, offenderNo = "QRE123"))
+
+    val remand = adjustmentRepository.findById(remandId.adjustmentId).get()
+
+    assertThat(remand.remand!!.unusedRemand.id).isEqualTo(unusedRemandId.adjustmentId)
+  }
+
+  @Test
+  fun `Create remand, and then create unused remand`() {
+    val remandId = createAdjustment(CREATED_ADJUSTMENT.copy(adjustmentType = LegacyAdjustmentType.RX, offenderNo = "XYZ321"))
+    val unusedRemandId = createAdjustment(CREATED_ADJUSTMENT.copy(adjustmentType = LegacyAdjustmentType.UR, offenderNo = "XYZ321"))
+
+    val remand = adjustmentRepository.findById(remandId.adjustmentId).get()
+
+    assertThat(remand.remand!!.unusedRemand.id).isEqualTo(unusedRemandId.adjustmentId)
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/ValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/ValidationServiceTest.kt
@@ -38,6 +38,7 @@ class ValidationServiceTest {
     days = 50,
     additionalDaysAwarded = null,
     unlawfullyAtLarge = null,
+    remand = null,
     lastUpdatedDate = LocalDateTime.now(),
   )
 


### PR DESCRIPTION
…ating of both adjustments from one request.

So here is the work I've been look at doing for unused remand. There are two parts of it.

1. The main reason for doing this is that we don't want an unused remand adjustment type in our service. Ideally we'd have a period of remand made up of a from and to date, with a calculated number of days in between. Then a property of that remand period would be how many days were unused by the release date calculation. That is very difficult to do and still integrate correctly with NOMIS where remand and unused remand are different adjustments. So all the work in the AdjustmentsService class is trying to manage two adjustments with a single adjustment object.
2. The other part of the work is mapping the NOMIS LegacyService to our model. This is complicates our data model, because in NOMIS they can change all aspects of the unused remand adjustment as its independent. Therefore we do create an adjustment in our database for the unused remand and then attempt to link it to the remand it should be associated with.

I'm mainly raising this PR for feedback, I'd be interested if anyone thinks there would be a better way to model this.