### PR TITLE
ADJST-830 Increase memory limit for adjudications.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,3 @@
 #
 # To stop the dps-gradle-spring-boot project from overwriting any project specific customisations here, remove the
 # warning at the top of this file.
-kotlin.incremental.useClasspathSnapshot=false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/config/WebClientConfiguration.kt
@@ -15,6 +15,7 @@ import org.springframework.security.oauth2.client.web.reactive.function.client.S
 import org.springframework.web.reactive.function.client.ClientRequest
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.ExchangeFunction
+import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
 
@@ -53,11 +54,16 @@ class WebClientConfiguration(
 
   @Bean
   fun adjudicationApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
+    val size = 4 * 1024 * 1024
+    val strategies = ExchangeStrategies.builder()
+      .codecs { it.defaultCodecs().maxInMemorySize(size) }
+      .build()
     val filter = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
     filter.setDefaultClientRegistrationId("hmpps-api")
     return WebClient.builder()
       .baseUrl(adjudicationsApiUri)
       .filter(filter)
+      .exchangeStrategies(strategies)
       .build()
   }
   private fun addAuthHeaderFilterFunction(): ExchangeFilterFunction {


### PR DESCRIPTION
Production bug where prisoner has 750KB of adjudication data. The default limit is 256KB, I've increased here to 4MB.