### PR TITLE
CRDS-796 Move from mono to flux as the response is very long

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/client/PrisonApiClient.kt
@@ -19,7 +19,6 @@ class PrisonApiClient(@Qualifier("prisonApiWebClient") private val webClient: We
     return webClient.get()
       .uri("/api/court-date-results/by-charge/$prisonerId")
       .retrieve()
-      .bodyToMono(typeReference<List<CourtDateChargeAndOutcomes>>())
       .block()!!
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/client/PrisonApiClient.kt
@@ -19,6 +19,8 @@ class PrisonApiClient(@Qualifier("prisonApiWebClient") private val webClient: We
     return webClient.get()
       .uri("/api/court-date-results/by-charge/$prisonerId")
       .retrieve()
+      .bodyToFlux(CourtDateChargeAndOutcomes::class.java)
+      .collectList()
       .block()!!
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/config/WebClientConfiguration.kt
@@ -32,6 +32,8 @@ class WebClientConfiguration(
   @Value("\${prisoner.search.api.timeout-seconds:90}") private val prisonerSearchApiTimeoutSeconds: Long,
 ) {
 
+  val customMemorySize = 4 * 1024 * 1024
+
   @Bean
   fun prisonerSearchApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = builder.authorisedWebClient(
     authorizedClientManager = authorizedClientManager,
@@ -41,12 +43,22 @@ class WebClientConfiguration(
   )
 
   @Bean
-  fun prisonApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = builder.authorisedWebClient(
-    authorizedClientManager = authorizedClientManager,
-    registrationId = "hmpps-api",
-    url = prisonApiUri,
-    timeout = Duration.ofSeconds(prisonApiTimeoutSeconds),
-  )
+  fun prisonApiWebClient(
+    authorizedClientManager: OAuth2AuthorizedClientManager,
+    builder: WebClient.Builder,
+  ): WebClient {
+    val strategies = ExchangeStrategies.builder()
+      .codecs { it.defaultCodecs().maxInMemorySize(customMemorySize) }
+      .build()
+    return builder
+      .exchangeStrategies(strategies)
+      .authorisedWebClient(
+        authorizedClientManager = authorizedClientManager,
+        registrationId = "hmpps-api",
+        url = prisonApiUri,
+        timeout = Duration.ofSeconds(prisonApiTimeoutSeconds),
+      )
+  }
 
   @Bean
   fun calculateReleaseDatesApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = builder.authorisedWebClient(
@@ -66,9 +78,8 @@ class WebClientConfiguration(
 
   @Bean
   fun adjudicationApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient {
-    val size = 4 * 1024 * 1024
     val strategies = ExchangeStrategies.builder()
-      .codecs { it.defaultCodecs().maxInMemorySize(size) }
+      .codecs { it.defaultCodecs().maxInMemorySize(customMemorySize) }
       .build()
     return builder
       .exchangeStrategies(strategies)


### PR DESCRIPTION
hmpps-adjustments-api-7f755c58f9-5jl59 hmpps-adjustments-api 2026-03-30T15:14:26.676463787+01:00        *__checkpoint ⇢ Body from GET https://prison-api-preprod.prison.service.justice.gov.uk/api/court-date-results/by-charge/A1337AZ [DefaultClientResponse]

hmpps-adjustments-api-7f755c58f9-5jl59 hmpps-adjustments-api 2026-03-30T15:14:26.676465708+01:00 Original Stack Trace:

hmpps-adjustments-api-7f755c58f9-5jl59 hmpps-adjustments-api 2026-03-30T15:14:26.676467395+01:00                at org.springframework.core.io.buffer.LimitedDataBufferList.raiseLimitException(LimitedDataBufferList.java:99)
