### PR TITLE
Update hmpps-sqs-spring-boot-starter to 7.3.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
   // Enable kotlin reflect
   implementation("org.jetbrains.kotlin:kotlin-reflect:2.3.21")
 
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.3.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.3.2")
 
   implementation("org.springframework:spring-jms:7.0.7")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/config/WebClientConfiguration.kt
@@ -3,18 +3,10 @@ package uk.gov.justice.digital.hmpps.adjustments.api.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.HttpHeaders
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
-import org.springframework.web.reactive.function.client.ClientRequest
-import org.springframework.web.reactive.function.client.ExchangeFilterFunction
-import org.springframework.web.reactive.function.client.ExchangeFunction
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
-import uk.gov.justice.hmpps.kotlin.auth.service.GlobalPrincipalOAuth2AuthorizedClientService
 import java.time.Duration
 
 @Configuration
@@ -89,26 +81,6 @@ class WebClientConfiguration(
         url = adjudicationsApiUri,
         timeout = Duration.ofSeconds(adjudicationsApiTimeoutSeconds),
       )
-  }
-
-  private fun addAuthHeaderFilterFunction(): ExchangeFilterFunction = ExchangeFilterFunction { request: ClientRequest, next: ExchangeFunction ->
-    val filtered = ClientRequest.from(request)
-      .header(HttpHeaders.AUTHORIZATION, UserContext.getAuthToken())
-      .build()
-    next.exchange(filtered)
-  }
-
-  @Bean
-  fun authorizedClientManager(
-    clientRegistrationRepository: ClientRegistrationRepository,
-  ): OAuth2AuthorizedClientManager {
-    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
-    val authorizedClientManager = AuthorizedClientServiceOAuth2AuthorizedClientManager(
-      clientRegistrationRepository,
-      GlobalPrincipalOAuth2AuthorizedClientService(clientRegistrationRepository),
-    )
-    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
-    return authorizedClientManager
   }
 
   @Bean

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/wiremock/HmppsAuthMockServer.kt
@@ -47,10 +47,11 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
           aResponse()
             .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
             .withBody(
-              """{
-                    "token_type": "bearer",
-                    "access_token": "ABCDE"
-                }
+              """
+              {
+                "token_type": "bearer",
+                "access_token": "atoken"
+              }
               """.trimIndent(),
             ),
         ),


### PR DESCRIPTION
For some reason this introduced some inconsistent auth failures. When we upgraded to spring boot 3 some of the auth handling was also updated but we were overriding some of the beans provided by the starter unnecessarily. Removing those beans and hoping auth still works as expected.