### PR TITLE
ADJST-1552: Prevent concurrent deactivate/unlink race on recall UAL adjustments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/config/RetryConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/config/RetryConfiguration.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.adjustments.api.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.retry.annotation.EnableRetry
+
+@Configuration
+@EnableRetry
+class RetryConfiguration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/legacy/service/LegacyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/legacy/service/LegacyService.kt
@@ -4,7 +4,16 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.hypersistence.utils.hibernate.type.json.internal.JacksonUtil
 import jakarta.persistence.EntityNotFoundException
+import org.hibernate.exception.LockAcquisitionException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.dao.CannotAcquireLockException
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.retry.annotation.Retryable
+import org.springframework.retry.support.RetrySynchronizationManager
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.adjustments.api.client.PrisonApiClient
 import uk.gov.justice.digital.hmpps.adjustments.api.client.PrisonerSearchApiClient
@@ -103,8 +112,15 @@ class LegacyService(
     )
   }
 
-  @Transactional
+  @Retryable(maxAttempts = 3, retryFor = [ObjectOptimisticLockingFailureException::class, CannotAcquireLockException::class, LockAcquisitionException::class])
+  @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.SERIALIZABLE)
   fun update(adjustmentId: UUID, resource: LegacyAdjustment): RecordResponse<LegacyAdjustmentUpdatedResponse> {
+    RetrySynchronizationManager.getContext()?.let { retryContext ->
+      if (retryContext.retryCount > 0) {
+        log.info("adjustment update retry with context: count = ${retryContext.retryCount}, lastException = ${retryContext.lastThrowable?.javaClass?.name}, exhausted=${retryContext.isExhaustedOnly}")
+      }
+    }
+    adjustmentRepository.acquireAdjustmentTransactionLock(adjustmentId)
     val adjustment = adjustmentRepository.findById(adjustmentId)
       .map { if (it.status.isDeleted()) null else it }
       .orElseThrow {
@@ -279,5 +295,9 @@ class LegacyService(
         )
       }
     }
+  }
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(LegacyService::class.java)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/respository/AdjustmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/respository/AdjustmentRepository.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.adjustments.api.respository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.adjustments.api.entity.Adjustment
 import uk.gov.justice.digital.hmpps.adjustments.api.entity.AdjustmentStatus
@@ -63,4 +64,15 @@ interface AdjustmentRepository : JpaRepository<Adjustment, UUID> {
     adjustmentType: AdjustmentType,
     status: AdjustmentStatus,
   ): List<Adjustment>
+
+  // Postgres advisory locks only accept bigint/int keys. Adjustment.id is a UUID, so hash it.
+  @Query(
+    value = """
+      select pg_try_advisory_xact_lock(hashtextextended(cast(a.id as text), 0))
+      from adjustment a
+      where a.id = :adjustmentId
+    """,
+    nativeQuery = true,
+  )
+  fun acquireAdjustmentTransactionLock(@Param("adjustmentId") adjustmentId: UUID)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/AdjustmentsTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/AdjustmentsTransactionalService.kt
@@ -6,8 +6,15 @@ import io.hypersistence.utils.hibernate.type.json.internal.JacksonUtil
 import jakarta.persistence.EntityNotFoundException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.hibernate.exception.LockAcquisitionException
+import org.springframework.dao.CannotAcquireLockException
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.retry.annotation.Retryable
+import org.springframework.retry.support.RetrySynchronizationManager
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.adjustments.api.client.PrisonApiClient
@@ -319,12 +326,21 @@ class AdjustmentsTransactionalService(
     recallId,
   ).map { mapToDto(it) }
 
-  @Transactional
-  fun unlinkFromRecall(recallId: UUID): List<AdjustmentDto> = adjustmentRepository
-    .findByRecallIdAndAdjustmentTypeAndStatus(recallId, UNLAWFULLY_AT_LARGE, ACTIVE)
-    .map { unlinkFromRecall(it) }
+  @Retryable(maxAttempts = 3, retryFor = [ObjectOptimisticLockingFailureException::class, CannotAcquireLockException::class, LockAcquisitionException::class])
+  @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.SERIALIZABLE)
+  fun unlinkFromRecall(recallId: UUID): List<AdjustmentDto> {
+    RetrySynchronizationManager.getContext()?.let { retryContext ->
+      if (retryContext.retryCount > 0) {
+        log.info("adjustment unlinkFromRecall retry with context: count = ${retryContext.retryCount}, lastException = ${retryContext.lastThrowable?.javaClass?.name}, exhausted=${retryContext.isExhaustedOnly}")
+      }
+    }
+    return adjustmentRepository
+      .findByRecallIdAndAdjustmentTypeAndStatus(recallId, UNLAWFULLY_AT_LARGE, ACTIVE)
+      .map { unlinkFromRecall(it) }
+  }
 
   private fun unlinkFromRecall(adjustment: Adjustment): AdjustmentDto {
+    adjustmentRepository.acquireAdjustmentTransactionLock(adjustment.id)
     val linkedRecallId = adjustment.recallId
     log.info("Unlinking UAL adjustment {} from recall {}", adjustment.id, linkedRecallId)
     val change = objectToJson(adjustment)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/AdjustmentsTransactionalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/service/AdjustmentsTransactionalService.kt
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.hypersistence.utils.hibernate.type.json.internal.JacksonUtil
 import jakarta.persistence.EntityNotFoundException
+import org.hibernate.exception.LockAcquisitionException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.hibernate.exception.LockAcquisitionException
 import org.springframework.dao.CannotAcquireLockException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.retry.annotation.Retryable

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/controller/AdjustmentControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/controller/AdjustmentControllerIntTest.kt
@@ -64,6 +64,7 @@ import uk.gov.justice.digital.hmpps.adjustments.api.wiremock.PrisonApiExtension
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
 
 class AdjustmentControllerIntTest : SqsIntegrationTestBase() {
 
@@ -1279,7 +1280,7 @@ class AdjustmentControllerIntTest : SqsIntegrationTestBase() {
       "classpath:test_data/reset-data.sql",
       "classpath:test_data/insert-adjustment-with-recall-id.sql",
     )
-    fun `Deactivate then unlink leaves adjustment inactive and unlinked`() {
+    fun `Race condition - concurrent deactivate and unlink leaves adjustment inactive`() {
       val adjustmentId = UUID.fromString("3f8a973b-c16e-46ef-8a02-07ac378d990e")
       val recallId = UUID.fromString("2ea3ae97-c469-491e-ae93-bdcda9d8ac91")
 
@@ -1288,12 +1289,29 @@ class AdjustmentControllerIntTest : SqsIntegrationTestBase() {
       assertThat(before.recallId).isEqualTo(recallId)
 
       val legacy = getLegacyAdjustment(adjustmentId)
-      updateLegacyAdjustment(adjustmentId, legacy.copy(active = false))
-      postUnlinkFromRecall(recallId)
+      val deactivateCall = CompletableFuture.supplyAsync {
+        webTestClient
+          .put()
+          .uri("/legacy/adjustments/$adjustmentId")
+          .headers(setLegacySynchronisationAuth())
+          .header("Content-Type", LegacyController.LEGACY_CONTENT_TYPE)
+          .bodyValue(legacy.copy(active = false))
+          .exchange()
+          .expectStatus().isOk
+      }
+      val unlinkCall = CompletableFuture.supplyAsync {
+        webTestClient
+          .post()
+          .uri("/adjustments/recall/$recallId/unlink")
+          .headers(setAdjustmentsRWAuth())
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().isEmpty
+      }
+      deactivateCall.thenCombine(unlinkCall) { a, b -> a to b }.join()
 
       val adjustment = adjustmentRepository.findById(adjustmentId).get()
       assertThat(adjustment.status).isEqualTo(AdjustmentStatus.INACTIVE)
-      assertThat(adjustment.recallId).isNull()
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/controller/AdjustmentControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/adjustments/api/controller/AdjustmentControllerIntTest.kt
@@ -1273,6 +1273,28 @@ class AdjustmentControllerIntTest : SqsIntegrationTestBase() {
       assertThat(latestMessage).contains(adjustmentId.toString())
       assertThat(latestMessage).contains(AdjustmentEventType.ADJUSTMENT_UPDATED.value)
     }
+
+    @Test
+    @Sql(
+      "classpath:test_data/reset-data.sql",
+      "classpath:test_data/insert-adjustment-with-recall-id.sql",
+    )
+    fun `Deactivate then unlink leaves adjustment inactive and unlinked`() {
+      val adjustmentId = UUID.fromString("3f8a973b-c16e-46ef-8a02-07ac378d990e")
+      val recallId = UUID.fromString("2ea3ae97-c469-491e-ae93-bdcda9d8ac91")
+
+      val before = adjustmentRepository.findById(adjustmentId).get()
+      assertThat(before.status).isEqualTo(ACTIVE)
+      assertThat(before.recallId).isEqualTo(recallId)
+
+      val legacy = getLegacyAdjustment(adjustmentId)
+      updateLegacyAdjustment(adjustmentId, legacy.copy(active = false))
+      postUnlinkFromRecall(recallId)
+
+      val adjustment = adjustmentRepository.findById(adjustmentId).get()
+      assertThat(adjustment.status).isEqualTo(AdjustmentStatus.INACTIVE)
+      assertThat(adjustment.recallId).isNull()
+    }
   }
 
   private fun getAdjustmentsByPerson(


### PR DESCRIPTION
This is to solve a race condition, where an action in NOMIS can result in two api calls running in parrallel to update an adjustment, resulting in a race condition issue

The solution ppplies the same race-condition-solution already used in hmpps-remand-and-sentencing-api.

The added test reproduced the problem.